### PR TITLE
chore: chore pin setup php version to avoid vuln report

### DIFF
--- a/.github/workflows/tests-7.x.yaml
+++ b/.github/workflows/tests-7.x.yaml
@@ -13,7 +13,7 @@ jobs:
         version: ['7.2', '7.3', '7.4']
     steps:
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@2.37.1
         with:
           php-version: ${{ matrix.version }}
       - name: Checkout Code


### PR DESCRIPTION
Closes https://github.com/Unleash/unleash-php-sdk/security/dependabot/2