### PR TITLE
chore: clean up lint allows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,6 +70,9 @@ jobs:
         run: composer require symfony/polyfill-php73:^1.0
       - name: Update composer.json version
         run: 'sed -i -e ''s/"php": "\^8.4"/"php": "\^${{ matrix.version }}"/'' composer.json'
+      - name: Pin simple-cache for Symfony Cache 5
+        if: matrix.version == '8.0'
+        run: 'sed -i -e ''s/"psr\/simple-cache": "\^1.0 | \^2.0 | \^3.0"/"psr\/simple-cache": "\^1.0 | \^2.0"/'' -e ''s/"psr\/simple-cache-implementation": "\^1.0 | \^2.0 | \^3.0"/"psr\/simple-cache-implementation": "\^1.0 | \^2.0"/'' composer.json'
       - name: Downgrade phpunit
         if: matrix.version == '7.2'
         run: 'sed -i -e ''s/"phpunit\/phpunit": "\^9.5"/"phpunit\/phpunit": "\^8.5"/'' composer.json'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -92,6 +92,9 @@ jobs:
         run: composer require symfony/polyfill-php73:^1.0
       - name: Update composer.json version
         run: 'sed -i -e ''s/"php": "\^8.4"/"php": "\^${{ matrix.version }}"/'' composer.json'
+      - name: Pin simple-cache for Symfony Cache 5
+        if: matrix.version == '8.0'
+        run: 'sed -i -e ''s/"psr\/simple-cache": "\^1.0 | \^2.0 | \^3.0"/"psr\/simple-cache": "\^1.0 | \^2.0"/'' -e ''s/"psr\/simple-cache-implementation": "\^1.0 | \^2.0 | \^3.0"/"psr\/simple-cache-implementation": "\^1.0 | \^2.0"/'' composer.json'
       - name: Downgrade phpunit
         if: matrix.version == '7.2'
         run: 'sed -i -e ''s/"phpunit\/phpunit": "\^9.5"/"phpunit\/phpunit": "\^8.5"/'' composer.json'

--- a/.github/workflows/transpile.yaml
+++ b/.github/workflows/transpile.yaml
@@ -28,6 +28,9 @@ jobs:
         run: composer require symfony/polyfill-php73:^1.0
       - name: Update composer.json version
         run: 'sed -i -e ''s/"php": "\^8.4"/"php": "\^${{ matrix.version }}"/'' composer.json'
+      - name: Pin simple-cache for Symfony Cache 5
+        if: matrix.version == '8.0'
+        run: 'sed -i -e ''s/"psr\/simple-cache": "\^1.0 | \^2.0 | \^3.0"/"psr\/simple-cache": "\^1.0 | \^2.0"/'' -e ''s/"psr\/simple-cache-implementation": "\^1.0 | \^2.0 | \^3.0"/"psr\/simple-cache-implementation": "\^1.0 | \^2.0"/'' composer.json'
       - name: Downgrade phpunit
         if: matrix.version == '7.2'
         run: 'sed -i -e ''s/"phpunit\/phpunit": "\^9.5"/"phpunit\/phpunit": "\^8.5"/'' composer.json'

--- a/src/DTO/DefaultVariant.php
+++ b/src/DTO/DefaultVariant.php
@@ -53,7 +53,6 @@ final readonly class DefaultVariant implements Variant
             assert(is_array($result['payload']));
         }
 
-        // @phpstan-ignore-next-line return.type
         return $result;
     }
 
@@ -99,7 +98,6 @@ final readonly class DefaultVariant implements Variant
             $variant->getStickiness(),
             $variant->getPayload(),
             $variant->getOverrides(),
-            // @phpstan-ignore-next-line function.alreadyNarrowedType
             $featureEnabled ?? (method_exists($variant, 'isFeatureEnabled') ? $variant->isFeatureEnabled() : false),
         );
     }

--- a/src/DTO/DefaultVariant.php
+++ b/src/DTO/DefaultVariant.php
@@ -37,7 +37,7 @@ final readonly class DefaultVariant implements Variant
     }
 
     /**
-     * @phpstan-return array<string|bool|array<string>>
+     * @phpstan-return array{name: string, enabled: bool, feature_enabled: bool, payload?: array<mixed, mixed>}
      */
     #[ArrayShape(['name' => 'string', 'enabled' => 'bool', 'payload' => 'mixed'])]
     #[Override]

--- a/src/DefaultUnleash.php
+++ b/src/DefaultUnleash.php
@@ -74,7 +74,8 @@ final readonly class DefaultUnleash implements Unleash
 
         $feature = $this->findFeature($featureName, $context);
         $enabledResult = $this->isFeatureEnabled($feature, $context);
-        $strategyVariants = $enabledResult->getStrategy()?->getVariants() ?? [];
+        $strategy = $enabledResult->getStrategy();
+        $strategyVariants = $strategy?->getVariants() ?? [];
         if (
             $feature === null
             || $enabledResult->isEnabled() === false
@@ -86,7 +87,9 @@ final readonly class DefaultUnleash implements Unleash
         if (!count($strategyVariants)) {
             $variant = $this->variantHandler->selectVariant($feature->getVariants(), $featureName, $context);
         } else {
-            $variant = $this->variantHandler->selectVariant($strategyVariants, $enabledResult->getStrategy()?->getParameters()['groupId'] ?? '', $context);
+            assert($strategy !== null);
+
+            $variant = $this->variantHandler->selectVariant($strategyVariants, $strategy->getParameters()['groupId'] ?? '', $context);
         }
         if ($variant !== null) {
             $this->metricsHandler->handleMetrics($feature, true, $variant);
@@ -161,7 +164,6 @@ final readonly class DefaultUnleash implements Unleash
             return new DefaultFeatureEnabledResult();
         }
 
-        // @phpstan-ignore-next-line function.alreadyNarrowedType
         $dependencies = method_exists($feature, 'getDependencies')
             ? $feature->getDependencies()
             : [];
@@ -248,7 +250,6 @@ final readonly class DefaultUnleash implements Unleash
         assert($dependency->getFeature() !== null);
 
         if (
-            // @phpstan-ignore-next-line function.alreadyNarrowedType
             method_exists($dependency->getFeature(), 'getDependencies')
             && count($dependency->getFeature()->getDependencies())
         ) {


### PR DESCRIPTION
Static analysis now fails on these, we can just remove them, they're not serving a purpose anymore

Also pins a cache version so transpiled versions work